### PR TITLE
ci/feat(seed-build): add windows and android build

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -38,7 +38,7 @@ jobs:
 
   build:
     if: ${{ github.event.pull_request.draft == false }}
-    uses: juicity/juicity/.github/workflows/seed-build.yml@ci/darwin-build
+    uses: juicity/juicity/.github/workflows/seed-build.yml@ci/windows_build
     with:
       ref: ${{ github.event.pull_request.head.sha }}
       pr-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -38,7 +38,7 @@ jobs:
 
   build:
     if: ${{ github.event.pull_request.draft == false }}
-    uses: juicity/juicity/.github/workflows/seed-build.yml@ci/windows_build
+    uses: juicity/juicity/.github/workflows/seed-build.yml@main
     with:
       ref: ${{ github.event.pull_request.head.sha }}
       pr-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/seed-build.yml
+++ b/.github/workflows/seed-build.yml
@@ -61,6 +61,16 @@ jobs:
           - goos: darwin
             goarch: arm64
           # END Darwin ARM64 AMD64
+          # BEGIN Windows ARM64 AMD64
+          - goos: windows
+            goarch: amd64
+          - goos: windows
+            goarch: arm64
+          # END Windows ARM64 AMD64
+          # BEGIN Android ARM64
+          - goos: android
+            goarch: arm64
+          # END Android ARM64
       fail-fast: false
 
     runs-on: ubuntu-latest
@@ -126,13 +136,14 @@ jobs:
           export CGO_ENABLED=0
           export GOFLAGS="-trimpath -modcacherw"
           export VERSION=${{ steps.get_version.outputs.VERSION }}
-          make
+          make all
           cp ./juicity-server ./build/
           cp ./juicity-client ./build/
 
       - name: Copy systemd service
         if: matrix.goos == 'linux'
         run: |
+          cp ./install/juicity-client.service ./build/
           cp ./install/juicity-server.service ./build/
 
       - name: Smoke test

--- a/install/friendly-filenames.json
+++ b/install/friendly-filenames.json
@@ -13,5 +13,8 @@
   "linux-mips": { "friendlyName": "linux-mips32" },
   "linux-riscv64": { "friendlyName": "linux-riscv64" },
   "darwin-amd64": { "friendlyName": "macos-x86_64" },
-  "darwin-arm64": { "friendlyName": "macos-arm64-v8a" }
+  "darwin-arm64": { "friendlyName": "macos-arm64" },
+  "windows-amd64": { "friendlyName": "windows-x86_64" },
+  "windows-arm64": { "friendlyName": "windows-arm64" },
+  "android-arm64": { "friendlyName": "android-arm64" }
 }


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

Add build support for windows_amd64, windows_arm64 and android_arm64.

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

