### PR TITLE
fix: should support hex fwmark

### DIFF
--- a/cmd/server/README.md
+++ b/cmd/server/README.md
@@ -40,7 +40,7 @@ Full configuration:
     "certificate": "/path/to/fullchain.cer",
     "private_key": "/path/to/private.key",
     "congestion_control": "bbr",
-    "fwmark": 0x1000,
+    "fwmark": "0x1000",
     "send_through": "113.25.132.3",
     "log_level": "info"
 }

--- a/cmd/server/run.go
+++ b/cmd/server/run.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"os"
 	"os/signal"
+	"strconv"
 	"syscall"
 
 	"github.com/juicity/juicity/config"
@@ -61,7 +62,11 @@ var (
 )
 
 func Serve(conf *config.Config) error {
-	if uint64(conf.Fwmark) > math.MaxInt || uint64(conf.Fwmark) > math.MaxUint32 {
+	fwmark, err := strconv.ParseUint(conf.Fwmark, 0, 32)
+	if err != nil {
+		return fmt.Errorf("parse fwmark: %w", err)
+	}
+	if uint64(fwmark) > math.MaxInt || uint64(fwmark) > math.MaxUint32 {
 		return fmt.Errorf("fwmark is too large")
 	}
 	s, err := server.New(&server.Options{
@@ -69,7 +74,7 @@ func Serve(conf *config.Config) error {
 		Certificate:       conf.Certificate,
 		PrivateKey:        conf.PrivateKey,
 		CongestionControl: conf.CongestionControl,
-		Fwmark:            conf.Fwmark,
+		Fwmark:            int(fwmark),
 		SendThrough:       conf.SendThrough,
 	})
 	if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -21,7 +21,7 @@ type Config struct {
 	Users       map[string]string `json:"users"`
 	Certificate string            `json:"certificate"`
 	PrivateKey  string            `json:"private_key"`
-	Fwmark      int               `json:"fwmark"`
+	Fwmark      string            `json:"fwmark"`
 	SendThrough string            `json:"send_through"`
 
 	// Common


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

`fwmark` should be hex instead of decimal.

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

