### PR TITLE
ci(build,pr-build,daily-build): enable check_run stages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,7 @@ jobs:
   #   secrets: inherit
 
   build:
+  #   needs: [pre-actions]
     uses: juicity/juicity/.github/workflows/seed-build.yml@main
     with:
       ref: ${{ github.sha }}
@@ -44,8 +45,8 @@ jobs:
     secrets: inherit
 
   # post-actions:
-  #   if: always()
   #   needs: [build]
+  #   if: always()
   #   uses: daeuniverse/ci-seed-jobs/.github/workflows/juicity-post-actions.yml@master
   #   with:
   #     check-run-id: "juicity-bot[bot]/main-build-passed"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,28 +27,30 @@ on:
       - "Makefile"
 
 jobs:
-  # pre-actions:
-  #   uses: daeuniverse/ci-seed-jobs/.github/workflows/pre-actions.yml@master
-  #   with:
-  #     repository: ${{ github.repository }}
-  #     ref: ${{ github.sha }}
-  #     fetch-depth: 0
-  #     check-runs: '["build", "main-build-passed"]'
-  #   secrets: inherit
+  pre-actions:
+    uses: daeuniverse/ci-seed-jobs/.github/workflows/pre-actions-public.yml@master
+    with:
+      repository: ${{ github.repository }}
+      ref: ${{ github.sha }}
+      fetch_depth: 0
+      check_runs: '["build", "main-build-passed"]'
+      bot_name: "juicity-bot"
+    secrets: inherit
 
   build:
-  #   needs: [pre-actions]
     uses: juicity/juicity/.github/workflows/seed-build.yml@main
     with:
       ref: ${{ github.sha }}
       build-type: main-build
     secrets: inherit
 
-  # post-actions:
-  #   needs: [build]
-  #   if: always()
-  #   uses: daeuniverse/ci-seed-jobs/.github/workflows/juicity-post-actions.yml@master
-  #   with:
-  #     check-run-id: "juicity-bot[bot]/main-build-passed"
-  #     check-run-conclusion: ${{ needs.build.result }}
-  #   secrets: inherit
+  post-actions:
+    needs: [build]
+    if: always()
+    uses: daeuniverse/ci-seed-jobs/.github/workflows/juicity-post-actions.yml@master
+    with:
+      check_run_id: "juicity-bot[bot]/main-build-passed"
+      check_run_conclusion: ${{ needs.build.result }}
+    secrets:
+      app_id: ${{ secrets.GH_APP_ID }}
+      private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
     uses: juicity/juicity/.github/workflows/seed-build.yml@main
     with:
       ref: ${{ github.sha }}
-      build-type: main-build
+      build_type: main-build
     secrets: inherit
 
   post-actions:

--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -19,13 +19,18 @@ on:
 
 jobs:
   pre-actions:
-    uses: daeuniverse/ci-seed-jobs/.github/workflows/pre-actions.yml@master
+    uses: daeuniverse/ci-seed-jobs/.github/workflows/pre-actions-public.yml@master
     with:
       repository: ${{ github.repository }}
       ref: ${{ github.sha }}
-      fetch-depth: 0
-      check-runs: '["build", "daily-build-passed"]'
-    secrets: inherit
+      fetch_depth: 0
+      check_runs: '["build", "daily-build-passed"]'
+      bot_name: "juicity-bot"
+    secrets:
+      app_id: ${{ secrets.GH_APP_ID }}
+      private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+      telegram_to: ${{ secrets.TELEGRAM_TO }}
+      telegram_token: ${{ secrets.TELEGRAM_TOKEN }}
 
   build:
     uses: juicity/juicity/.github/workflows/seed-build.yml@main
@@ -38,6 +43,8 @@ jobs:
     needs: [build]
     uses: daeuniverse/ci-seed-jobs/.github/workflows/juicity-post-actions.yml@master
     with:
-      check-run-id: "juicity-bot[bot]/daily-build-passed"
-      check-run-conclusion: ${{ needs.build.result }}
-    secrets: inherit
+      check_run-id: "juicity-bot[bot]/daily-build-passed"
+      check_run-conclusion: ${{ needs.build.result }}
+    secrets:
+      app_id: ${{ secrets.GH_APP_ID }}
+      private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}

--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -36,7 +36,7 @@ jobs:
     uses: juicity/juicity/.github/workflows/seed-build.yml@main
     with:
       ref: ${{ github.sha }}
-      build-type: daily-build
+      build_type: daily-build
 
   post-actions:
     if: always()

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -47,8 +47,8 @@ jobs:
     uses: juicity/juicity/.github/workflows/seed-build.yml@main
     with:
       ref: ${{ github.event.pull_request.head.sha }}
-      pr-number: ${{ github.event.pull_request.number }}
-      build-type: pr-build
+      pr_number: ${{ github.event.pull_request.number }}
+      build_type: pr-build
     secrets:
       app_id: ${{ secrets.GH_APP_ID }}
       private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -38,6 +38,8 @@ jobs:
     secrets:
       app_id: ${{ secrets.GH_APP_ID }}
       private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+      telegram_to: ${{ secrets.TELEGRAM_TO }}
+      telegram_token: ${{ secrets.TELEGRAM_TOKEN }}
 
   build:
     needs: [pre-actions]

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -26,30 +26,31 @@ on:
       - ".github/workflows/seed-build.yml"
 
 jobs:
-  # pre-actions:
-  #   if: ${{ github.event.pull_request.draft == false }}
-  #   uses: daeuniverse/ci-seed-jobs/.github/workflows/pre-actions.yml@master
-  #   with:
-  #     repository: ${{ github.repository }}
-  #     ref: ${{ github.event.pull_request.head.sha }}
-  #     fetch-depth: 0
-  #     check-runs: '["build", "pr-build-passed"]'
-  #   secrets: inherit
+  pre-actions:
+    if: ${{ github.event.pull_request.draft == false }}
+    uses: daeuniverse/ci-seed-jobs/.github/workflows/pre-actions.yml@master
+    with:
+      repository: ${{ github.repository }}
+      ref: ${{ github.event.pull_request.head.sha }}
+      fetch-depth: 0
+      check-runs: '["build", "pr-build-passed"]'
+    secrets: inherit
 
   build:
+    needs: [pre-actions]
     if: ${{ github.event.pull_request.draft == false }}
-    uses: juicity/juicity/.github/workflows/seed-build.yml@main
+    uses: juicity/juicity/.github/workflows/seed-build.yml@pr_check_run
     with:
       ref: ${{ github.event.pull_request.head.sha }}
       pr-number: ${{ github.event.pull_request.number }}
       build-type: pr-build
     secrets: inherit
 
-  # post-actions:
-  #   if: always()
-  #   needs: [build]
-  #   uses: daeuniverse/ci-seed-jobs/.github/workflows/juicity--post-actions.yml@master
-  #   with:
-  #     check-run-id: "juicity-bot[bot]/pr-build-passed"
-  #     check-run-conclusion: ${{ needs.build.result }}
-  #   secrets: inherit
+  post-actions:
+    needs: [build]
+    if: always()
+    uses: daeuniverse/ci-seed-jobs/.github/workflows/juicity--post-actions.yml@master
+    with:
+      check-run-id: "juicity-bot[bot]/pr-build-passed"
+      check-run-conclusion: ${{ needs.build.result }}
+    secrets: inherit

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -44,7 +44,7 @@ jobs:
   build:
     needs: [pre-actions]
     if: ${{ github.event.pull_request.draft == false }}
-    uses: juicity/juicity/.github/workflows/seed-build.yml@pr_check_run
+    uses: juicity/juicity/.github/workflows/seed-build.yml@main
     with:
       ref: ${{ github.event.pull_request.head.sha }}
       pr-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -28,12 +28,15 @@ on:
 jobs:
   pre-actions:
     if: ${{ github.event.pull_request.draft == false }}
-    uses: daeuniverse/ci-seed-jobs/.github/workflows/pre-actions.yml@master
+    uses: daeuniverse/ci-seed-jobs/.github/workflows/pre-actions-public.yml@master
     with:
       repository: ${{ github.repository }}
       ref: ${{ github.event.pull_request.head.sha }}
-      fetch-depth: 0
-      check-runs: '["build", "pr-build-passed"]'
+      fetch_depth: 0
+      check_runs: '["build", "pr-build-passed"]'
+      app_id: ${{ secrets.GH_APP_ID }}
+      private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+      bot_name: "juicity-bot"
     secrets: inherit
 
   build:
@@ -51,6 +54,8 @@ jobs:
     if: always()
     uses: daeuniverse/ci-seed-jobs/.github/workflows/juicity-post-actions.yml@master
     with:
-      check-run-id: "juicity-bot[bot]/pr-build-passed"
-      check-run-conclusion: ${{ needs.build.result }}
+      check_run_id: "juicity-bot[bot]/pr-build-passed"
+      check_run_conclusion: ${{ needs.build.result }}
+      app_id: ${{ secrets.GH_APP_ID }}
+      private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
     secrets: inherit

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -49,7 +49,7 @@ jobs:
   post-actions:
     needs: [build]
     if: always()
-    uses: daeuniverse/ci-seed-jobs/.github/workflows/juicity--post-actions.yml@master
+    uses: daeuniverse/ci-seed-jobs/.github/workflows/juicity-post-actions.yml@master
     with:
       check-run-id: "juicity-bot[bot]/pr-build-passed"
       check-run-conclusion: ${{ needs.build.result }}

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -49,7 +49,9 @@ jobs:
       ref: ${{ github.event.pull_request.head.sha }}
       pr-number: ${{ github.event.pull_request.number }}
       build-type: pr-build
-    secrets: inherit
+    secrets:
+      app_id: ${{ secrets.GH_APP_ID }}
+      private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
 
   post-actions:
     needs: [build]

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -34,10 +34,10 @@ jobs:
       ref: ${{ github.event.pull_request.head.sha }}
       fetch_depth: 0
       check_runs: '["build", "pr-build-passed"]'
+      bot_name: "juicity-bot"
+    secrets:
       app_id: ${{ secrets.GH_APP_ID }}
       private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-      bot_name: "juicity-bot"
-    secrets: inherit
 
   build:
     needs: [pre-actions]
@@ -56,6 +56,6 @@ jobs:
     with:
       check_run_id: "juicity-bot[bot]/pr-build-passed"
       check_run_conclusion: ${{ needs.build.result }}
+    secrets:
       app_id: ${{ secrets.GH_APP_ID }}
       private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-    secrets: inherit

--- a/.github/workflows/seed-build.yml
+++ b/.github/workflows/seed-build.yml
@@ -19,10 +19,10 @@ on:
         type: string
         required: true
         default: ${{ github.ref }}
-      pr-number:
+      pr_number:
         type: number
         required: false
-      build-type:
+      build_type:
         type: string
         description: "[pr-build,main-build,daily-build]"
 
@@ -101,9 +101,9 @@ jobs:
         run: |
           date=$(git log -1 --format="%cd" --date=short | sed s/-//g)
           commit=$(echo ${REF} | cut -c1-6)
-          if [[ "${{ inputs.build-type }}" == "pr-build" ]]; then
+          if [[ "${{ inputs.build_type }}" == "pr-build" ]]; then
             count=$(git rev-list --count origin/main..HEAD)
-            version="unstable-${date}.pr-${{ inputs.pr-number }}.r${count}.${commit}"
+            version="unstable-${date}.pr-${{ inputs.pr_number }}.r${count}.${commit}"
           else
             count=$(git rev-list --count HEAD)
             version="unstable-${date}.r${count}.${commit}"
@@ -179,7 +179,7 @@ jobs:
 
       - name: Report result
         uses: daeuniverse/ci-seed-jobs/common/report-check-run@master
-        if: always() && inputs.build-type == 'pr-build' && startsWith(github.event.pull_request.head.repo.full_name, github.repository_owner)
+        if: always() && inputs.build_type == 'pr-build' && startsWith(github.event.pull_request.head.repo.full_name, github.repository_owner)
         with:
           app_id: ${{ secrets.app_id }}
           private_key: ${{ secrets.private_key }}

--- a/.github/workflows/seed-build.yml
+++ b/.github/workflows/seed-build.yml
@@ -26,6 +26,12 @@ on:
         type: string
         description: "[pr-build,main-build,daily-build]"
 
+    secrets:
+      app_id:
+        required: true
+      private_key:
+        required: true
+
 jobs:
   build:
     strategy:
@@ -171,11 +177,11 @@ jobs:
           name: juicity-${{ steps.get_filename.outputs.ASSET_NAME }}.zip
           path: build/*
 
-      # - name: Report result
-      #   uses: daeuniverse/ci-seed-jobs/common/report-check-run@master
-      #   if: always() && inputs.build-type == 'pr-build' && startsWith(github.event.pull_request.head.repo.full_name, github.repository_owner)
-      #   with:
-      #     app_id: ${{ secrets.GH_APP_ID }}
-      #     private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-      #     id: "juicity-bot[bot]/build"
+      - name: Report result
+        uses: daeuniverse/ci-seed-jobs/common/report-check-run@master
+        if: always() && inputs.build-type == 'pr-build' && startsWith(github.event.pull_request.head.repo.full_name, github.repository_owner)
+        with:
+          app_id: ${{ secrets.app_id }}
+          private_key: ${{ secrets.private_key }}
+          id: "juicity-bot[bot]/build"
 

--- a/.github/workflows/seed-release-build.yml
+++ b/.github/workflows/seed-release-build.yml
@@ -168,7 +168,7 @@ jobs:
 
       # - name: Report result
       #   uses: daeuniverse/ci-seed-jobs/common/report-check-run@master
-      #   if: always() && inputs.build-type == 'pr-build' && startsWith(github.event.pull_request.head.repo.full_name, github.repository_owner)
+      #   if: always()
       #   with:
       #     app_id: ${{ secrets.GH_APP_ID }}
       #     private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

Enable `pre-actions` and `post-actions` stages in [build,pr-build,daily-build].

### Checklist

- [ ] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full changelogs

- ci(pr-build): enable check_run stages
- fix: inherit secrets from org_secrets
- feat: add telegram-creds for pre-actions
- feat(daily-build): enable pre-actions and post-actions stages
- feat(build): enable pre-actions and post-actions stages
- patch(seed-build): enable report status stage
- chore: use underscore notations for reusable workflow inputs

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->

NA

### Test Result

<!--- Attach test result here. -->

https://github.com/juicity/juicity/actions/runs/5705680442

<img width="712" alt="image" src="https://github.com/juicity/juicity/assets/31861128/0170da39-3a15-45b8-ba63-3cd2c52692ba">