### PR TITLE
docs: add authentication docs of http/socks5 listening

### DIFF
--- a/cmd/client/README.md
+++ b/cmd/client/README.md
@@ -37,7 +37,7 @@ make juicity-client
 }
 ```
 
-- `listen` is the address that the socks5 and http server listen at.
+- `listen` is the address that the socks5 and http server listen at. If you want authentication, write it like `user:pass@:1080`.
 - Optional values of `congestion_control`: cubic, bbr, new_reno.
 - `sni` can be omitted if domain is given in `server`.
 - Set environment variable `QUIC_GO_ENABLE_GSO=true` to enable GSO, which can greatly improve the performance of sending and receiving packets. Notice that this option needs the support of NIC features. See more: <https://github.com/juicity/juicity/discussions/42>


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

As title.

### Checklist

- [ ] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [x] There is a user-facing docs PR against https://github.com/juicity/juicity

### Full changelogs

- Update client/README.md.

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->

Closes #41

