### PR TITLE
feat: support certificate pinning

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Juicity is implemented with the following goals:
 Full parameters:
 
 ```shell
-juicity://uuid:password@122.12.31.66:port?congestion_control=bbr&sni=www.example.com&allow_insecure=0
+juicity://uuid:password@122.12.31.66:port?congestion_control=bbr&sni=www.example.com&allow_insecure=0&pinned_certchain_sha256=CERT_HASH
 ```
 
 Mini parameters:

--- a/cmd/client/README.md
+++ b/cmd/client/README.md
@@ -24,6 +24,8 @@ make juicity-client
 
 ## Configuration
 
+Mini config:
+
 ```json
 {
   "listen": ":1080",
@@ -37,9 +39,26 @@ make juicity-client
 }
 ```
 
+Full config:
+
+```json
+{
+  "listen": ":1080",
+  "server": "<ip or domain>:<port>",
+  "uuid": "00000000-0000-0000-0000-000000000000",
+  "password": "my_password",
+  "sni": "www.example.com",
+  "allow_insecure": false,
+  "congestion_control": "bbr",
+  "pinned_certchain_sha256": "aQc4fdF4Nh1PD6MsCB3eofRyfRz5R8jJ1afgr37ABZs=",
+  "log_level": "info"
+}
+```
+
 - `listen` is the address that the socks5 and http server listen at. If you want authentication, write it like `user:pass@:1080`.
 - Optional values of `congestion_control`: cubic, bbr, new_reno.
 - `sni` can be omitted if domain is given in `server`.
+- `pinned_certchain_sha256` is the pinned hash of remote TLS certificate chain. You can generate it by `uicity-server generate-certchain-hash [fullchain_cert_file]`. See <https://github.com/juicity/juicity/issues/34>.
 - Set environment variable `QUIC_GO_ENABLE_GSO=true` to enable GSO, which can greatly improve the performance of sending and receiving packets. Notice that this option needs the support of NIC features. See more: <https://github.com/juicity/juicity/discussions/42>
 
 ## Arguments

--- a/cmd/client/README.md
+++ b/cmd/client/README.md
@@ -58,7 +58,7 @@ Full configuration:
 - `listen` is the address that the socks5 and http server listen at. If you want authentication, write it like `user:pass@:1080`.
 - Optional values of `congestion_control`: cubic, bbr, new_reno.
 - `sni` can be omitted if domain is given in `server`.
-- `pinned_certchain_sha256` is the pinned hash of remote TLS certificate chain. You can generate it by `uicity-server generate-certchain-hash [fullchain_cert_file]`. See <https://github.com/juicity/juicity/issues/34>.
+- `pinned_certchain_sha256` is the pinned hash of remote TLS certificate chain. You can generate it by `juicity-server generate-certchain-hash [fullchain_cert_file]`. See <https://github.com/juicity/juicity/issues/34>.
 - Set environment variable `QUIC_GO_ENABLE_GSO=true` to enable GSO, which can greatly improve the performance of sending and receiving packets. Notice that this option needs the support of NIC features. See more: <https://github.com/juicity/juicity/discussions/42>
 
 ## Arguments

--- a/cmd/client/README.md
+++ b/cmd/client/README.md
@@ -24,7 +24,7 @@ make juicity-client
 
 ## Configuration
 
-Mini config:
+Mini configuration:
 
 ```json
 {
@@ -39,7 +39,7 @@ Mini config:
 }
 ```
 
-Full config:
+Full configuration:
 
 ```json
 {

--- a/cmd/client/run.go
+++ b/cmd/client/run.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"bytes"
 	"crypto/tls"
+	"crypto/x509"
+	"encoding/base64"
 	"fmt"
 	stdlog "log"
 	"net"
@@ -17,6 +20,7 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/spf13/cobra"
 
+	"github.com/juicity/juicity/common"
 	"github.com/juicity/juicity/config"
 	"github.com/juicity/juicity/pkg/client/dialer"
 	"github.com/juicity/juicity/pkg/log"
@@ -97,19 +101,33 @@ func Serve(conf *config.Config) error {
 	if conf.Sni == "" {
 		conf.Sni, _, _ = net.SplitHostPort(conf.Server)
 	}
+	tlsConfig := &tls.Config{
+		NextProtos:         []string{"h3"},
+		MinVersion:         tls.VersionTLS13,
+		ServerName:         conf.Sni,
+		InsecureSkipVerify: conf.AllowInsecure,
+	}
+	if conf.PinnedCertChainSha256 != "" {
+		pinnedHash, err := base64.StdEncoding.DecodeString(conf.PinnedCertChainSha256)
+		if err != nil {
+			return fmt.Errorf("decode pin_certchain_sha256: %w", err)
+		}
+		tlsConfig.InsecureSkipVerify = true
+		tlsConfig.VerifyPeerCertificate = func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
+			if !bytes.Equal(common.GenerateCertChainHash(rawCerts), pinnedHash) {
+				return fmt.Errorf("pinned hash of cert chain does not match")
+			}
+			return nil
+		}
+	}
 	d, err := juicity.NewDialer(dialer.NewClientDialer(conf), protocol.Header{
 		ProxyAddress: conf.Server,
 		Feature1:     conf.CongestionControl,
-		TlsConfig: &tls.Config{
-			NextProtos:         []string{"h3"},
-			MinVersion:         tls.VersionTLS13,
-			ServerName:         conf.Sni,
-			InsecureSkipVerify: conf.AllowInsecure,
-		},
-		User:     conf.Uuid,
-		Password: conf.Password,
-		IsClient: true,
-		Flags:    0,
+		TlsConfig:    tlsConfig,
+		User:         conf.Uuid,
+		Password:     conf.Password,
+		IsClient:     true,
+		Flags:        0,
 	})
 	if err != nil {
 		return err

--- a/cmd/server/README.md
+++ b/cmd/server/README.md
@@ -24,7 +24,7 @@ make CGO_ENABLED=0 juicity-server
 
 ## Configuration
 
-Min configuration:
+Mini configuration:
 
 ```json
 {

--- a/cmd/server/gen_certchain_hash.go
+++ b/cmd/server/gen_certchain_hash.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"encoding/base64"
+	"encoding/pem"
+	"fmt"
+	"os"
+
+	"github.com/juicity/juicity/common"
+	"github.com/spf13/cobra"
+)
+
+var (
+	genCertchainHashCmd = &cobra.Command{
+		Use:                   "generate-certchain-hash [fullchain_file]",
+		DisableFlagsInUseLine: true,
+		Short:                 "To generate the hash of a full chain certificate.",
+		Run: func(cmd *cobra.Command, args []string) {
+			if len(args) == 0 {
+				cmd.Help()
+				os.Exit(1)
+			}
+			hash, err := generateCertChainHash(args[0])
+			if err != nil {
+				fmt.Println(err)
+				os.Exit(0)
+			}
+			fmt.Println(hash)
+		},
+	}
+)
+
+func generateCertChainHash(file string) (string, error) {
+	b, err := os.ReadFile(file)
+	if err != nil {
+		return "", err
+	}
+	var rawCerts [][]byte
+	for {
+		block, rest := pem.Decode(b)
+		if block == nil {
+			break
+		}
+		rawCerts = append(rawCerts, block.Bytes)
+		b = rest
+	}
+	if len(rawCerts) == 0 {
+		return "", fmt.Errorf("not a certificate file")
+	}
+	return base64.StdEncoding.EncodeToString(common.GenerateCertChainHash(rawCerts)), nil
+}
+
+func init() {
+	// cmds
+	rootCmd.AddCommand(genCertchainHashCmd)
+}

--- a/cmd/server/gen_certchain_hash.go
+++ b/cmd/server/gen_certchain_hash.go
@@ -17,7 +17,7 @@ var (
 		Short:                 "To generate the hash of a full chain certificate.",
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(args) == 0 {
-				cmd.Help()
+				_ = cmd.Help()
 				os.Exit(1)
 			}
 			hash, err := generateCertChainHash(args[0])

--- a/common/utils.go
+++ b/common/utils.go
@@ -1,0 +1,16 @@
+package common
+
+import "crypto/sha256"
+
+func GenerateCertChainHash(rawCerts [][]byte) (chainHash []byte) {
+	for _, cert := range rawCerts {
+		certHash := sha256.Sum256(cert)
+		if chainHash == nil {
+			chainHash = certHash[:]
+		} else {
+			newHash := sha256.Sum256(append(chainHash, certHash[:]...))
+			chainHash = newHash[:]
+		}
+	}
+	return chainHash
+}

--- a/config/config.go
+++ b/config/config.go
@@ -11,12 +11,13 @@ var (
 
 type Config struct {
 	// Client
-	Server        string `json:"server"`
-	Uuid          string `json:"uuid"`
-	Password      string `json:"password"`
-	Sni           string `json:"sni"`
-	AllowInsecure bool   `json:"allow_insecure"`
-	ProtectPath   string `json:"protect_path"`
+	Server                string `json:"server"`
+	Uuid                  string `json:"uuid"`
+	Password              string `json:"password"`
+	Sni                   string `json:"sni"`
+	AllowInsecure         bool   `json:"allow_insecure"`
+	PinnedCertChainSha256 string `json:"pinned_certchain_sha256"`
+	ProtectPath           string `json:"protect_path"`
 
 	// Server
 	Users       map[string]string `json:"users"`


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

Sometimes, we want to use a self-signed certificate without trusting it in the system. This PR implements `Certificate Pinning` to solve it.

### Checklist

- [x] The Pull Request has been fully tested
- [x] There's an entry in the CHANGELOGS
- [x] There is a user-facing docs PR against https://github.com/juicity/juicity

### Full changelogs

- Support `juicity-server generate-certchain-hash [cert_file]`.
- Support the `pinned_certchain_sha256` config item.

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->

Closes #34

### Test Result

<!--- Attach test result here. -->
Normal case:
<img width="747" alt="image" src="https://github.com/juicity/juicity/assets/30586220/13377189-002b-48b9-b00c-d4e82875f780">

Abnormal case (hash unmatched):
<img width="740" alt="image" src="https://github.com/juicity/juicity/assets/30586220/2ed0d386-8787-4182-b20f-ab212f84a86c">


