### PR TITLE
feat(server): support cmd generate-sharelink

### DIFF
--- a/cmd/server/README.md
+++ b/cmd/server/README.md
@@ -86,3 +86,11 @@ uuidgen
 ```
 
 Also see [#63](https://github.com/juicity/juicity/issues/63)
+
+## Generate ShareLink
+
+```bash
+juicity-server generate-sharinglink -c /etc/juicity/server.json
+# output
+juicity://00000000-0000-0000-0000-000000000000:mypassword@1.2.3.4:15333?congestion_control=bbr&pinned_certchain_sha256=5ykL73pOK7NAu92A48dCrFjDqDowdChUSmlpQzudmvc%3D&sni=example.com
+```

--- a/cmd/server/gen_certchain_hash.go
+++ b/cmd/server/gen_certchain_hash.go
@@ -47,7 +47,7 @@ func generateCertChainHash(file string) (string, error) {
 	if len(rawCerts) == 0 {
 		return "", fmt.Errorf("not a certificate file")
 	}
-	return base64.StdEncoding.EncodeToString(common.GenerateCertChainHash(rawCerts)), nil
+	return base64.URLEncoding.EncodeToString(common.GenerateCertChainHash(rawCerts)), nil
 }
 
 func init() {

--- a/cmd/server/gen_link.go
+++ b/cmd/server/gen_link.go
@@ -18,9 +18,9 @@ import (
 
 var (
 	genLinkCmd = &cobra.Command{
-		Use:                   "generate-sharinglink [config_file]",
+		Use:                   "generate-sharelink [config_file]",
 		DisableFlagsInUseLine: true,
-		Short:                 "To generate the sharing link from the config file.",
+		Short:                 "To generate the sharelink from the config file.",
 		Run: func(cmd *cobra.Command, args []string) {
 			link, err := generateLink(shared.GetArguments())
 			if err != nil {

--- a/cmd/server/gen_link.go
+++ b/cmd/server/gen_link.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"time"
+
+	"github.com/juicity/juicity/cmd/internal/shared"
+	"github.com/spf13/cobra"
+)
+
+var (
+	genLinkCmd = &cobra.Command{
+		Use:                   "generate-sharinglink [config_file]",
+		DisableFlagsInUseLine: true,
+		Short:                 "To generate the sharing link from the config file.",
+		Run: func(cmd *cobra.Command, args []string) {
+			link, err := generateLink(shared.GetArguments())
+			if err != nil {
+				fmt.Println(err)
+				os.Exit(1)
+			}
+			fmt.Println(link)
+		},
+	}
+)
+
+func generateLink(arguments shared.Arguments) (string, error) {
+	conf, err := arguments.GetConfig()
+	if err != nil {
+		return "", err
+	}
+	_, port, err := net.SplitHostPort(conf.Listen)
+	if err != nil {
+		return "", fmt.Errorf("parse 'listen': %w", err)
+	}
+	if len(conf.Users) == 0 {
+		return "", fmt.Errorf("no users")
+	}
+	var (
+		uuid     string
+		password string
+	)
+	for uuid, password = range conf.Users {
+		break
+	}
+	// Validate the cert and key.
+	tlsCert, err := tls.LoadX509KeyPair(conf.Certificate, conf.PrivateKey)
+	if err != nil {
+		return "", err
+	}
+	cert, err := x509.ParseCertificate(tlsCert.Certificate[0])
+	if err != nil {
+		return "", err
+	}
+
+	// Get cert hash.
+	hash, err := generateCertChainHash(conf.Certificate)
+	if err != nil {
+		return "", fmt.Errorf("generateCertChainHash: %w", err)
+	}
+	timeout := 10 * time.Second
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	r := net.Resolver{
+		PreferGo: true,
+		Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
+			d := net.Dialer{
+				Timeout: time.Duration(timeout) * time.Millisecond,
+			}
+			return d.DialContext(ctx, "tcp", "208.67.222.222:53")
+		},
+	}
+
+	// Get IP address.
+	addrs, _ := r.LookupHost(ctx, "myip.opendns.com")
+	if len(addrs) == 0 {
+		http.DefaultClient.Timeout = timeout
+		resp, err := http.Get("https://myipv4.p1.opendns.com/get_my_ip")
+		if err != nil {
+			return "", err
+		}
+		defer resp.Body.Close()
+		var respBody struct {
+			IP string `json:"ip"`
+		}
+		if err = json.NewDecoder(resp.Body).Decode(&respBody); err != nil {
+			return "", err
+		}
+		addrs = []string{respBody.IP}
+	}
+	link := url.URL{
+		Scheme: "juicity",
+		User:   url.UserPassword(uuid, password),
+		Host:   net.JoinHostPort(addrs[0], port),
+		RawQuery: url.Values{
+			"congestion_control":      []string{"bbr"},
+			"sni":                     []string{cert.Subject.CommonName},
+			"pinned_certchain_sha256": []string{hash},
+		}.Encode(),
+	}
+	return link.String(), nil
+}
+
+func init() {
+	// cmds
+	rootCmd.AddCommand(genLinkCmd)
+
+	// flags
+	shared.InitArgumentsFlags(genLinkCmd)
+}


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

For example:

```bash
> ./juicity-server generate-sharinglink -c /etc/juicity/server.json
juicity://00000000-0000-0000-0000-000000000000:mypassword@1.2.3.4:15333?congestion_control=bbr&pinned_certchain_sha256=5ykL73pOK7NAu92A48dCrFjDqDowdChUSmlpQzudmvc%3D&sni=download.microsoft.com
```

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/juicity/juicity

### Full changelogs

- feat(server): support cmd generate-sharinglink

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->

Closes #_[issue number]_

### Test Result

<!--- Attach test result here. -->
