### PR TITLE
optimize(generate-sharelink): judge whether really need to pin

### DIFF
--- a/cmd/server/README.md
+++ b/cmd/server/README.md
@@ -90,7 +90,7 @@ Also see [#63](https://github.com/juicity/juicity/issues/63)
 ## Generate ShareLink
 
 ```bash
-juicity-server generate-sharinglink -c /etc/juicity/server.json
+juicity-server generate-sharelink -c /etc/juicity/server.json
 # output
 juicity://00000000-0000-0000-0000-000000000000:mypassword@1.2.3.4:15333?congestion_control=bbr&pinned_certchain_sha256=5ykL73pOK7NAu92A48dCrFjDqDowdChUSmlpQzudmvc%3D&sni=example.com
 ```


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

In main branch version, `juicity-server generate-sharelink -c [config.json]` always generates `pinned_certchain_sha256` whether or not the cert is self-signed. This PR optimizes it.

### Checklist

- [ ] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/juicity/juicity

### Full Changelogs

- Generate `pinned_certchain_sha256` only if the cert is self-signed.

### Issue Reference

<!--- If it fixes an open issue, please link to the issue here. -->

NA

### Test Result

<!--- Attach test result here. -->
<img width="1296" alt="image" src="https://github.com/juicity/juicity/assets/30586220/abb60308-e0e4-4935-bae2-f16c25b20581">
