### PR TITLE
fix: fail to trigger auth timeout in some cases

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -168,8 +168,8 @@ func (s *Server) handleConn(conn quic.Connection) (err error) {
 }
 
 func (s *Server) handleStream(ctx context.Context, authCtx context.Context, conn quic.Connection, stream quic.Stream) error {
-	defer stream.Close()
 	lConn := juicity.NewConn(stream, nil, nil)
+	defer lConn.Close()
 	// Read the header and initiate the metadata
 	_, err := lConn.Read(nil)
 	if err != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -139,10 +139,10 @@ func (s *Server) handleConn(conn quic.Connection) (err error) {
 	common.SetCongestionController(conn, s.congestionControl, s.cwnd)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	authCtx, authDone := context.WithCancel(ctx)
+	authCtx, authDone := context.WithTimeout(ctx, AuthenticateTimeout)
 	defer authDone()
 	go func() {
-		if _, err := s.handleAuth(ctx, conn); err != nil {
+		if _, err := s.handleAuth(authCtx, conn); err != nil {
 			s.logger.Warn().
 				Err(err).
 				Msg("handleAuth")
@@ -157,13 +157,13 @@ func (s *Server) handleConn(conn quic.Connection) (err error) {
 		if err != nil {
 			return err
 		}
-		go func(ctx context.Context, authCtx context.Context, conn quic.Connection, stream quic.Stream) {
+		go func(stream quic.Stream) {
 			if err = s.handleStream(ctx, authCtx, conn, stream); err != nil {
 				s.logger.Warn().
 					Err(err).
 					Send()
 			}
-		}(ctx, authCtx, conn, stream)
+		}(stream)
 	}
 }
 
@@ -269,8 +269,6 @@ func (s *Server) handleStream(ctx context.Context, authCtx context.Context, conn
 }
 
 func (s *Server) handleAuth(ctx context.Context, conn quic.Connection) (uuid *uuid.UUID, err error) {
-	ctx, cancel := context.WithTimeout(ctx, AuthenticateTimeout)
-	defer cancel()
 	uniStream, err := conn.AcceptUniStream(ctx)
 	if err != nil {
 		return nil, err
@@ -301,7 +299,7 @@ func (s *Server) handleAuth(ctx context.Context, conn quic.Connection) (uuid *uu
 				if token == authenticate.TOKEN {
 					return &authenticate.UUID, nil
 				} else {
-					_ = conn.CloseWithError(tuic.AuthenticationFailed, ErrAuthenticationFailed.Error())
+					_ = conn.CloseWithError(tuic.AuthenticationFailed, "")
 				}
 			}
 			return nil, fmt.Errorf("%w: %v", ErrAuthenticationFailed, authenticate.UUID)


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

If an unistream is opened but data is read slowly and even longer than 10 seconds, the auth timeout will not be triggered, which is abnormal.

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/juicity/juicity

### Full Changelogs

- [Implement ...]

### Issue Reference

<!--- If it fixes an open issue, please link to the issue here. -->

Closes #_[issue number]_

### Test Result

<!--- Attach test result here. -->
