### PR TITLE
Fix docker image build failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG APP_DIR=/app
 
 ### Builder ###
-FROM golang:1.20-alpine AS builder
+FROM golang:1.21-alpine AS builder
 
 ARG APP_DIR
 


### PR DESCRIPTION
### Background

Docker image builds failed due to go version incompatibility:

```
 => ERROR [builder 5/7] RUN go mod download                                                                        2.6s
------
 > [builder 5/7] RUN go mod download:
2.416 go: errors parsing go.mod:
2.416 /app/go.mod:3: invalid go version '1.21.0': must match format 1.23
------
Dockerfile:13
--------------------
  11 |
  12 |     COPY go.mod go.sum ./
  13 | >>> RUN go mod download
  14 |
  15 |     COPY . .
--------------------
ERROR: failed to solve: process "/bin/sh -c go mod download" did not complete successfully: exit code: 1
```
### Checklist

- [x] The Pull Request has been fully tested
- [] There's an entry in the CHANGELOGS
- [x] There is a user-facing docs PR against https://github.com/juicity/juicity

### Full Changelogs

- resolved the issue by changing the builder image in Dockerfile from `golang:1.20-alpine` to `golang:1.21-alpine`

### Issue Reference

<!--- If it fixes an open issue, please link to the issue here. -->

Closes #114


