### PR TITLE
feat(cmd): enhance version print

### DIFF
--- a/.github/workflows/seed-build.yml
+++ b/.github/workflows/seed-build.yml
@@ -156,8 +156,8 @@ jobs:
       - name: Smoke test
         if: matrix.goarch == 'amd64' && matrix.goamd64 == 'v1'
         run: |
-          ./build/juicity-server --version
-          ./build/juicity-client --version
+          ./build/juicity-server version
+          ./build/juicity-client version
 
       - name: Create binary ZIP archive and Signature
         run: |
@@ -184,4 +184,3 @@ jobs:
           app_id: ${{ secrets.app_id }}
           private_key: ${{ secrets.private_key }}
           id: "juicity-bot[bot]/build"
-

--- a/.github/workflows/seed-release-build.yml
+++ b/.github/workflows/seed-release-build.yml
@@ -146,8 +146,8 @@ jobs:
       - name: Smoke test
         if: matrix.goarch == 'amd64' && matrix.goamd64 == 'v1'
         run: |
-          ./build/juicity-server --version
-          ./build/juicity-client --version
+          ./build/juicity-server version
+          ./build/juicity-client version
 
       - name: Create binary ZIP archive and Signature
         run: |
@@ -173,4 +173,3 @@ jobs:
       #     app_id: ${{ secrets.GH_APP_ID }}
       #     private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
       #     id: "juicity-bot[bot]/build"
-

--- a/Makefile
+++ b/Makefile
@@ -13,12 +13,12 @@ all: juicity-server juicity-client
 
 juicity-server:
 	go build -o $@ -trimpath \
-		 -ldflags "-s -w -X 'github.com/juicity/juicity/config.Version=$(VERSION)' -X 'github.com/juicity/juicity/config.Runtime=$(RUNTIME)'" \
+		 -ldflags "-s -w -X github.com/juicity/juicity/config.Version=$(VERSION)" \
 		 ./cmd/server
 
 juicity-client:
 	go build -o $@ -trimpath \
-		 -ldflags "-s -w -X 'github.com/juicity/juicity/config.Version=$(VERSION)' -X 'github.com/juicity/juicity/config.Runtime=$(RUNTIME)'" \
+		 -ldflags "-s -w -X github.com/juicity/juicity/config.Version=$(VERSION)" \
 		 ./cmd/client
 
 .PHONY: juicity-server juicity-client all

--- a/Makefile
+++ b/Makefile
@@ -8,16 +8,19 @@ else
 	VERSION ?= unstable-$(date).r$(count).$(commit)
 endif
 RUNTIME=$(shell go version)
+ifndef CGO_ENALBED
+    CGO_ENALBED := 0
+endif
 
 all: juicity-server juicity-client
 
 juicity-server:
-	go build -o $@ -trimpath \
+	CGO_ENALBED=$CGO_ENALBED go build -o $@ -trimpath \
 		 -ldflags "-s -w -X github.com/juicity/juicity/config.Version=$(VERSION)" \
 		 ./cmd/server
 
 juicity-client:
-	go build -o $@ -trimpath \
+	CGO_ENALBED=$CGO_ENALBED go build -o $@ -trimpath \
 		 -ldflags "-s -w -X github.com/juicity/juicity/config.Version=$(VERSION)" \
 		 ./cmd/client
 

--- a/Makefile
+++ b/Makefile
@@ -7,13 +7,18 @@ ifeq ($(wildcard .git/.),)
 else
 	VERSION ?= unstable-$(date).r$(count).$(commit)
 endif
+RUNTIME=$(shell go version)
 
 all: juicity-server juicity-client
 
 juicity-server:
-	go build -o $@ -trimpath -ldflags "-s -w -X github.com/juicity/juicity/config.Version=$(VERSION)" ./cmd/server
+	go build -o $@ -trimpath \
+		 -ldflags "-s -w -X 'github.com/juicity/juicity/config.Version=$(VERSION)' -X 'github.com/juicity/juicity/config.Runtime=$(RUNTIME)'" \
+		 ./cmd/server
 
 juicity-client:
-	go build -o $@ -trimpath -ldflags "-s -w -X github.com/juicity/juicity/config.Version=$(VERSION)" ./cmd/client
+	go build -o $@ -trimpath \
+		 -ldflags "-s -w -X 'github.com/juicity/juicity/config.Version=$(VERSION)' -X 'github.com/juicity/juicity/config.Runtime=$(RUNTIME)'" \
+		 ./cmd/client
 
 .PHONY: juicity-server juicity-client all

--- a/Makefile
+++ b/Makefile
@@ -2,25 +2,26 @@
 date=$(shell git log -1 --format="%cd" --date=short | sed s/-//g)
 count=$(shell git rev-list --count HEAD)
 commit=$(shell git rev-parse --short HEAD)
+
 ifeq ($(wildcard .git/.),)
 	VERSION ?= unstable-0.nogit
 else
 	VERSION ?= unstable-$(date).r$(count).$(commit)
 endif
-RUNTIME=$(shell go version)
-ifndef CGO_ENALBED
-    CGO_ENALBED := 0
+
+ifndef CGO_ENABLED
+	CGO_ENABLED := 0
 endif
 
 all: juicity-server juicity-client
 
 juicity-server:
-	CGO_ENALBED=$CGO_ENALBED go build -o $@ -trimpath \
+	CGO_ENABLED=$(CGO_ENABLED) go build -o $@ -trimpath \
 		 -ldflags "-s -w -X github.com/juicity/juicity/config.Version=$(VERSION)" \
 		 ./cmd/server
 
 juicity-client:
-	CGO_ENALBED=$CGO_ENALBED go build -o $@ -trimpath \
+	CGO_ENABLED=$(CGO_ENABLED) go build -o $@ -trimpath \
 		 -ldflags "-s -w -X github.com/juicity/juicity/config.Version=$(VERSION)" \
 		 ./cmd/client
 

--- a/cmd/client/cgo_check.go
+++ b/cmd/client/cgo_check.go
@@ -1,0 +1,8 @@
+//go:build cgo
+// +build cgo
+
+package main
+
+func init() {
+	cgoEnabled = 1
+}

--- a/cmd/client/cmd.go
+++ b/cmd/client/cmd.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"runtime"
 
 	"github.com/juicity/juicity/config"
 	"github.com/spf13/cobra"
@@ -24,8 +25,13 @@ func init() {
 		Use:   "version",
 		Short: "Print out version info",
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Printf("juicity-client version %v\n%v\n", config.Version, config.Runtime)
-			fmt.Printf("CGO_ENALBED: %v\n", os.Getenv("CGO_ENALBED"))
+			fmt.Printf("juicity-client version %v\n", config.Version)
+			fmt.Printf("go version %v %v/%v\n", runtime.Version(), runtime.GOOS, runtime.GOARCH)
+			if val, isSet := os.LookupEnv("CGO_ENALBED"); !isSet {
+				fmt.Print("CGO_ENALBED: NOT SET\n")
+			} else {
+				fmt.Printf("CGO_ENALBED: %v\n", val)
+			}
 		},
 	})
 }

--- a/cmd/client/cmd.go
+++ b/cmd/client/cmd.go
@@ -1,21 +1,34 @@
 package main
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/juicity/juicity/config"
 	"github.com/spf13/cobra"
 )
 
 var (
 	rootCmd = &cobra.Command{
-		Use:     "juicity-client [flags] [command [argument ...]]",
-		Short:   "juicity-client is a quic-based proxy client.",
-		Long:    "juicity-client is a quic-based proxy client.",
-		Version: config.Version,
+		Use:   "juicity-client [flags] [command [argument ...]]",
+		Short: "juicity-client is a quic-based proxy client.",
+		Long:  "juicity-client is a quic-based proxy client.",
 		CompletionOptions: cobra.CompletionOptions{
 			DisableDefaultCmd: true,
 		},
 	}
 )
+
+func init() {
+	rootCmd.AddCommand(&cobra.Command{
+		Use:   "version",
+		Short: "Print out version info",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Printf("juicity-client version %v\n%v\n", config.Version, config.Runtime)
+			fmt.Printf("CGO_ENALBED: %v\n", os.Getenv("CGO_ENALBED"))
+		},
+	})
+}
 
 // Execute executes the root command.
 func Execute() error {

--- a/cmd/client/cmd.go
+++ b/cmd/client/cmd.go
@@ -1,16 +1,12 @@
 package main
 
 import (
-	"fmt"
-	"os"
-	"runtime"
-
-	"github.com/juicity/juicity/config"
 	"github.com/spf13/cobra"
 )
 
 var (
-	rootCmd = &cobra.Command{
+	cgoEnabled = 0
+	rootCmd    = &cobra.Command{
 		Use:   "juicity-client [flags] [command [argument ...]]",
 		Short: "juicity-client is a quic-based proxy client.",
 		Long:  "juicity-client is a quic-based proxy client.",
@@ -21,19 +17,7 @@ var (
 )
 
 func init() {
-	rootCmd.AddCommand(&cobra.Command{
-		Use:   "version",
-		Short: "Print out version info",
-		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Printf("juicity-client version %v\n", config.Version)
-			fmt.Printf("go version %v %v/%v\n", runtime.Version(), runtime.GOOS, runtime.GOARCH)
-			if val, isSet := os.LookupEnv("CGO_ENALBED"); !isSet {
-				fmt.Print("CGO_ENALBED: NOT SET\n")
-			} else {
-				fmt.Printf("CGO_ENALBED: %v\n", val)
-			}
-		},
-	})
+	rootCmd.AddCommand()
 }
 
 // Execute executes the root command.

--- a/cmd/client/run.go
+++ b/cmd/client/run.go
@@ -40,7 +40,7 @@ var (
 		Run: func(cmd *cobra.Command, args []string) {
 			fmt.Printf("juicity-client version %v\n", config.Version)
 			fmt.Printf("go version %v %v/%v\n", runtime.Version(), runtime.GOOS, runtime.GOARCH)
-			fmt.Printf("CGO_ENALBED: %v\n", cgoEnabled)
+			fmt.Printf("CGO_ENABLED: %v\n", cgoEnabled)
 		},
 	}
 

--- a/cmd/client/run.go
+++ b/cmd/client/run.go
@@ -11,7 +11,6 @@ import (
 	"net"
 	"os"
 	"os/signal"
-	"runtime"
 	"syscall"
 	"time"
 
@@ -38,9 +37,7 @@ var (
 		Use:   "version",
 		Short: "Print out version info",
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Printf("juicity-client version %v\n", config.Version)
-			fmt.Printf("go version %v %v/%v\n", runtime.Version(), runtime.GOOS, runtime.GOARCH)
-			fmt.Printf("CGO_ENABLED: %v\n", cgoEnabled)
+			shared.PrintVersion(cgoEnabled)
 		},
 	}
 
@@ -175,6 +172,9 @@ func Serve(conf *config.Config) error {
 }
 
 func init() {
+	// version
+	rootCmd.Version = shared.GetVersion(cgoEnabled)
+
 	// cmds
 	rootCmd.AddCommand(runCmd)
 	rootCmd.AddCommand(versionCmd)

--- a/cmd/client/run.go
+++ b/cmd/client/run.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"os"
 	"os/signal"
+	"runtime"
 	"syscall"
 	"time"
 
@@ -32,6 +33,16 @@ var (
 	logger = log.NewLogger(&log.Options{
 		TimeFormat: time.DateTime,
 	})
+
+	versionCmd = &cobra.Command{
+		Use:   "version",
+		Short: "Print out version info",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Printf("juicity-client version %v\n", config.Version)
+			fmt.Printf("go version %v %v/%v\n", runtime.Version(), runtime.GOOS, runtime.GOARCH)
+			fmt.Printf("CGO_ENALBED: %v\n", cgoEnabled)
+		},
+	}
 
 	runCmd = &cobra.Command{
 		Use:   "run",
@@ -166,5 +177,7 @@ func Serve(conf *config.Config) error {
 func init() {
 	// cmds
 	rootCmd.AddCommand(runCmd)
+	rootCmd.AddCommand(versionCmd)
+
 	shared.InitArgumentsFlags(runCmd)
 }

--- a/cmd/internal/shared/version.go
+++ b/cmd/internal/shared/version.go
@@ -3,16 +3,27 @@ package shared
 import (
 	"fmt"
 	"runtime"
+	"strings"
 
 	"github.com/juicity/juicity/config"
 )
 
+func multiline(parts ...string) string {
+	return strings.Join(parts, "\n")
+}
+
 func PrintVersion(cgoEnabled int) {
-	fmt.Printf("juicity-client version %v\n", config.Version)
-	fmt.Printf("go version %v %v/%v\n", runtime.Version(), runtime.GOOS, runtime.GOARCH)
-	fmt.Printf("CGO_ENABLED: %v\n", cgoEnabled)
+	fmt.Print(multiline(
+		fmt.Sprintf("juicity-client version %v", config.Version),
+		fmt.Sprintf("go version %v %v/%v", runtime.Version(), runtime.GOOS, runtime.GOARCH),
+		fmt.Sprintf("CGO_ENABLED: %v\n", cgoEnabled),
+	))
 }
 
 func GetVersion(cgoEnabled int) string {
-	return fmt.Sprintf("juicity-client version %v\ngo version %v %v/%v\nCGO_ENABLED: %v", config.Version, runtime.Version(), runtime.GOOS, runtime.GOARCH, cgoEnabled)
+	return multiline(
+		fmt.Sprintf("juicity-client version %v", config.Version),
+		fmt.Sprintf("go version %v %v/%v", runtime.Version(), runtime.GOOS, runtime.GOARCH),
+		fmt.Sprintf("CGO_ENABLED: %v", cgoEnabled),
+	)
 }

--- a/cmd/internal/shared/version.go
+++ b/cmd/internal/shared/version.go
@@ -1,0 +1,18 @@
+package shared
+
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/juicity/juicity/config"
+)
+
+func PrintVersion(cgoEnabled int) {
+	fmt.Printf("juicity-client version %v\n", config.Version)
+	fmt.Printf("go version %v %v/%v\n", runtime.Version(), runtime.GOOS, runtime.GOARCH)
+	fmt.Printf("CGO_ENABLED: %v\n", cgoEnabled)
+}
+
+func GetVersion(cgoEnabled int) string {
+	return fmt.Sprintf("juicity-client version %v\ngo version %v %v/%v\nCGO_ENABLED: %v", config.Version, runtime.Version(), runtime.GOOS, runtime.GOARCH, cgoEnabled)
+}

--- a/cmd/server/cgo_check.go
+++ b/cmd/server/cgo_check.go
@@ -1,0 +1,8 @@
+//go:build cgo
+// +build cgo
+
+package main
+
+func init() {
+	cgoEnabled = 1
+}

--- a/cmd/server/cmd.go
+++ b/cmd/server/cmd.go
@@ -1,21 +1,34 @@
 package main
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/juicity/juicity/config"
 	"github.com/spf13/cobra"
 )
 
 var (
 	rootCmd = &cobra.Command{
-		Use:     "juicity-server [flags] [command [argument ...]]",
-		Short:   "juicity-server is a quic-based proxy server.",
-		Long:    "juicity-server is a quic-based proxy server.",
-		Version: config.Version,
+		Use:   "juicity-server [flags] [command [argument ...]]",
+		Short: "juicity-server is a quic-based proxy server.",
+		Long:  "juicity-server is a quic-based proxy server.",
 		CompletionOptions: cobra.CompletionOptions{
 			DisableDefaultCmd: true,
 		},
 	}
 )
+
+func init() {
+	rootCmd.AddCommand(&cobra.Command{
+		Use:   "version",
+		Short: "Print out version info",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Printf("juicity-server version %v\n%v\n", config.Version, config.Runtime)
+			fmt.Printf("CGO_ENALBED: %v\n", os.Getenv("CGO_ENALBED"))
+		},
+	})
+}
 
 // Execute executes the root command.
 func Execute() error {

--- a/cmd/server/cmd.go
+++ b/cmd/server/cmd.go
@@ -25,7 +25,11 @@ func init() {
 		Short: "Print out version info",
 		Run: func(cmd *cobra.Command, args []string) {
 			fmt.Printf("juicity-server version %v\n%v\n", config.Version, config.Runtime)
-			fmt.Printf("CGO_ENALBED: %v\n", os.Getenv("CGO_ENALBED"))
+			if val, isSet := os.LookupEnv("CGO_ENALBED"); !isSet {
+				fmt.Print("CGO_ENALBED: NOT SET\n")
+			} else {
+				fmt.Printf("CGO_ENALBED: %v\n", val)
+			}
 		},
 	})
 }

--- a/cmd/server/cmd.go
+++ b/cmd/server/cmd.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"runtime"
 
 	"github.com/juicity/juicity/config"
 	"github.com/spf13/cobra"
@@ -24,7 +25,8 @@ func init() {
 		Use:   "version",
 		Short: "Print out version info",
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Printf("juicity-server version %v\n%v\n", config.Version, config.Runtime)
+			fmt.Printf("juicity-client version %v\n", config.Version)
+			fmt.Printf("go version %v %v/%v\n", runtime.Version(), runtime.GOOS, runtime.GOARCH)
 			if val, isSet := os.LookupEnv("CGO_ENALBED"); !isSet {
 				fmt.Print("CGO_ENALBED: NOT SET\n")
 			} else {

--- a/cmd/server/cmd.go
+++ b/cmd/server/cmd.go
@@ -1,16 +1,12 @@
 package main
 
 import (
-	"fmt"
-	"os"
-	"runtime"
-
-	"github.com/juicity/juicity/config"
 	"github.com/spf13/cobra"
 )
 
 var (
-	rootCmd = &cobra.Command{
+	cgoEnabled = 0
+	rootCmd    = &cobra.Command{
 		Use:   "juicity-server [flags] [command [argument ...]]",
 		Short: "juicity-server is a quic-based proxy server.",
 		Long:  "juicity-server is a quic-based proxy server.",
@@ -19,22 +15,6 @@ var (
 		},
 	}
 )
-
-func init() {
-	rootCmd.AddCommand(&cobra.Command{
-		Use:   "version",
-		Short: "Print out version info",
-		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Printf("juicity-client version %v\n", config.Version)
-			fmt.Printf("go version %v %v/%v\n", runtime.Version(), runtime.GOOS, runtime.GOARCH)
-			if val, isSet := os.LookupEnv("CGO_ENALBED"); !isSet {
-				fmt.Print("CGO_ENALBED: NOT SET\n")
-			} else {
-				fmt.Printf("CGO_ENALBED: %v\n", val)
-			}
-		},
-	})
-}
 
 // Execute executes the root command.
 func Execute() error {

--- a/cmd/server/run.go
+++ b/cmd/server/run.go
@@ -5,7 +5,6 @@ import (
 	"math"
 	"os"
 	"os/signal"
-	"runtime"
 	"strconv"
 	"syscall"
 	"time"
@@ -27,9 +26,7 @@ var (
 		Use:   "version",
 		Short: "Print out version info",
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Printf("juicity-client version %v\n", config.Version)
-			fmt.Printf("go version %v %v/%v\n", runtime.Version(), runtime.GOOS, runtime.GOARCH)
-			fmt.Printf("CGO_ENABLED: %v\n", cgoEnabled)
+			shared.PrintVersion(cgoEnabled)
 		},
 	}
 
@@ -108,6 +105,9 @@ func Serve(conf *config.Config) (err error) {
 }
 
 func init() {
+	// version
+	rootCmd.Version = shared.GetVersion(cgoEnabled)
+
 	// cmds
 	rootCmd.AddCommand(runCmd)
 	rootCmd.AddCommand(versionCmd)

--- a/cmd/server/run.go
+++ b/cmd/server/run.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"os"
 	"os/signal"
+	"runtime"
 	"strconv"
 	"syscall"
 	"time"
@@ -21,6 +22,16 @@ var (
 	logger = log.NewLogger(&log.Options{
 		TimeFormat: time.DateTime,
 	})
+
+	versionCmd = &cobra.Command{
+		Use:   "version",
+		Short: "Print out version info",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Printf("juicity-client version %v\n", config.Version)
+			fmt.Printf("go version %v %v/%v\n", runtime.Version(), runtime.GOOS, runtime.GOARCH)
+			fmt.Printf("CGO_ENALBED: %v\n", cgoEnabled)
+		},
+	}
 
 	runCmd = &cobra.Command{
 		Use:   "run",
@@ -99,6 +110,7 @@ func Serve(conf *config.Config) (err error) {
 func init() {
 	// cmds
 	rootCmd.AddCommand(runCmd)
+	rootCmd.AddCommand(versionCmd)
 
 	// flags
 	shared.InitArgumentsFlags(runCmd)

--- a/cmd/server/run.go
+++ b/cmd/server/run.go
@@ -29,7 +29,7 @@ var (
 		Run: func(cmd *cobra.Command, args []string) {
 			fmt.Printf("juicity-client version %v\n", config.Version)
 			fmt.Printf("go version %v %v/%v\n", runtime.Version(), runtime.GOOS, runtime.GOARCH)
-			fmt.Printf("CGO_ENALBED: %v\n", cgoEnabled)
+			fmt.Printf("CGO_ENABLED: %v\n", cgoEnabled)
 		},
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -7,7 +7,6 @@ import (
 
 var (
 	Version = "unknown"
-	Runtime = "unknown"
 )
 
 type Config struct {

--- a/config/config.go
+++ b/config/config.go
@@ -7,6 +7,7 @@ import (
 
 var (
 	Version = "unknown"
+	Runtime = "unknown"
 )
 
 type Config struct {


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

## Background

<!--- Why is this change required? What problem does it solve? -->

As the user requested in #122, we added support to extend the default version of print info.

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/juicity/juicity

### Full Changelogs

- feat(cmd): enhance version print
- patch: do not print empty val if env not exist
- ci(smoke_test): use version instead of --version
- refactor: retrieve cgo compilation var by specifying tag at build time

### Issue Reference

<!--- If it fixes an open issue, please link to the issue here. -->

Closes #122 

## How it works

In Go, we can check if the `CGO_ENABLED` environment variable is set during the _**build**_ process using _**build tags**_. The `CGO_ENABLED` environment variable determines whether or not cgo (the Go tool for working with C) is enabled. We can conditionally include or exclude code based on the value of this environment variable. 

In https://github.com/juicity/juicity/pull/123/commits/afd4d60df4dd73dcca4f76a7008fba9a6c792dda, we use the build tag `cgo` to specify that `cgo_check.go` should only be included when `CGO_ENABLED` is set to `1`.

## Tests

### Round 1:

By default `CGO_ENALBED` is set to `0` or `OFF`

```console
◆ juicity git:(version_enhancement) ❯❯❯ make                                                01:01:06
CGO_ENALBED=GO_ENALBED go build -o juicity-server -trimpath \
         -ldflags "-s -w -X github.com/juicity/juicity/config.Version=unstable-20230913.r115.afd4d60" \
         ./cmd/server
CGO_ENALBED=GO_ENALBED go build -o juicity-client -trimpath \
         -ldflags "-s -w -X github.com/juicity/juicity/config.Version=unstable-20230913.r115.afd4d60" \
         ./cmd/client
◆ juicity git:(version_enhancement) ❯❯❯ ./juicity-server version                            01:01:11
juicity-client version unstable-20230913.r115.afd4d60
go version go1.21.1 linux/amd64
CGO_ENABLED: 0
```

### Round 2: 

Set `CGO_ENABLED=0` at build time

```console
◆ juicity git:(version_enhancement) ❯❯❯ CGO_ENABLED=0 make                                  01:02:32
CGO_ENALBED=GO_ENALBED go build -o juicity-server -trimpath \
         -ldflags "-s -w -X github.com/juicity/juicity/config.Version=unstable-20230913.r115.afd4d60" \
         ./cmd/server
CGO_ENALBED=GO_ENALBED go build -o juicity-client -trimpath \
         -ldflags "-s -w -X github.com/juicity/juicity/config.Version=unstable-20230913.r115.afd4d60" \
         ./cmd/client
◆ juicity git:(version_enhancement) ❯❯❯ ./juicity-server version                            01:02:37
juicity-client version unstable-20230913.r115.afd4d60
go version go1.21.1 linux/amd64
CGO_ENABLED: 0
```

### Round 3: 

Set `CGO_ENABLED=1` at build time

```console
◆ juicity git:(version_enhancement) ❯❯❯ CGO_ENABLED=1 make                                  01:03:00
CGO_ENALBED=GO_ENALBED go build -o juicity-server -trimpath \
         -ldflags "-s -w -X github.com/juicity/juicity/config.Version=unstable-20230913.r115.afd4d60" \
         ./cmd/server
CGO_ENALBED=GO_ENALBED go build -o juicity-client -trimpath \
         -ldflags "-s -w -X github.com/juicity/juicity/config.Version=unstable-20230913.r115.afd4d60" \
         ./cmd/client
◆ juicity git:(version_enhancement) ❯❯❯ ./juicity-server version                            01:03:03
juicity-client version unstable-20230913.r115.afd4d60
go version go1.21.1 linux/amd64
CGO_ENABLED: 1
```