### PR TITLE
Fixed docker CI did not start when workflow update, add linux/arm64 Docker image

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -83,6 +83,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -18,6 +18,7 @@ on:
       - "go.sum"
       - ".github/workflows/pr-build.yml"
       - ".github/workflows/seed-build.yml"
+      - ".github/workflows/docker-publish.yml"
   pull_request:
     branches: [ "main" ]
     paths:
@@ -28,6 +29,7 @@ on:
       - "go.sum"
       - ".github/workflows/pr-build.yml"
       - ".github/workflows/seed-build.yml"
+      - ".github/workflows/docker-publish.yml"
 
 env:
   # Use docker.io for Docker Hub if empty


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->
Fixed docker CI did not start when workflow update, add linux/arm64 Docker image

### Checklist

- [x] The Pull Request has been fully tested
- [x] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/juicity/juicity

### Full Changelogs

- add linux/arm64 Docker image

### Issue Reference

<!--- If it fixes an open issue, please link to the issue here. -->

### Test Result

https://github.com/EkkoG/juicity/actions/runs/6610538011
