### PR TITLE
feat(cmd/version): add copy right and license info

### DIFF
--- a/cmd/internal/shared/version.go
+++ b/cmd/internal/shared/version.go
@@ -17,6 +17,8 @@ func PrintVersion(cgoEnabled int) {
 		fmt.Sprintf("juicity-client version %v", config.Version),
 		fmt.Sprintf("go version %v %v/%v", runtime.Version(), runtime.GOOS, runtime.GOARCH),
 		fmt.Sprintf("CGO_ENABLED: %v\n", cgoEnabled),
+		"Copyright (c) 2023 juicity",
+		"License GNU AGPLv3 <https://github.com/juicity/juicity/blob/main/LICENSE>",
 	))
 }
 
@@ -25,5 +27,7 @@ func GetVersion(cgoEnabled int) string {
 		fmt.Sprintf("juicity-client version %v", config.Version),
 		fmt.Sprintf("go version %v %v/%v", runtime.Version(), runtime.GOOS, runtime.GOARCH),
 		fmt.Sprintf("CGO_ENABLED: %v", cgoEnabled),
+		"Copyright (c) 2023 juicity",
+		"License GNU AGPLv3 <https://github.com/juicity/juicity/blob/main/LICENSE>",
 	)
 }

--- a/cmd/internal/shared/version.go
+++ b/cmd/internal/shared/version.go
@@ -15,7 +15,7 @@ func multiline(parts ...string) string {
 func PrintVersion(cgoEnabled int) {
 	fmt.Print(multiline(
 		fmt.Sprintf("juicity-client version %v", config.Version),
-		fmt.Sprintf("go version %v %v/%v", runtime.Version(), runtime.GOOS, runtime.GOARCH),
+		fmt.Sprintf("go runtime %v %v/%v", runtime.Version(), runtime.GOOS, runtime.GOARCH),
 		fmt.Sprintf("CGO_ENABLED: %v\n", cgoEnabled),
 		"Copyright (c) 2023 juicity",
 		"License GNU AGPLv3 <https://github.com/juicity/juicity/blob/main/LICENSE>",
@@ -25,7 +25,7 @@ func PrintVersion(cgoEnabled int) {
 func GetVersion(cgoEnabled int) string {
 	return multiline(
 		fmt.Sprintf("juicity-client version %v", config.Version),
-		fmt.Sprintf("go version %v %v/%v", runtime.Version(), runtime.GOOS, runtime.GOARCH),
+		fmt.Sprintf("go runtime %v %v/%v", runtime.Version(), runtime.GOOS, runtime.GOARCH),
 		fmt.Sprintf("CGO_ENABLED: %v", cgoEnabled),
 		"Copyright (c) 2023 juicity",
 		"License GNU AGPLv3 <https://github.com/juicity/juicity/blob/main/LICENSE>",


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

Add copy-right and license info to version cmd.

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/juicity/juicity

### Full Changelogs

- feat(cmd/version): add copy right and license info

### Issue Reference

<!--- If it fixes an open issue, please link to the issue here. -->

NA

### Test Result

<!--- Attach test result here. -->

```console
◆ juicity git:(extra-info) ❯❯❯ make                                                                                                                       23:12:37
CGO_ENABLED=0 go build -o juicity-server -trimpath \
         -ldflags "-s -w -X github.com/juicity/juicity/config.Version=unstable-20231024.r117.9e449a0" \
         ./cmd/server
CGO_ENABLED=0 go build -o juicity-client -trimpath \
         -ldflags "-s -w -X github.com/juicity/juicity/config.Version=unstable-20231024.r117.9e449a0" \
         ./cmd/client
◆ juicity git:(extra-info) ❯❯❯ ./juicity-server --version                                                                                                 23:12:40
juicity-server version juicity-client version unstable-20231024.r117.9e449a0
go version go1.21.1 linux/amd64
CGO_ENABLED: 0
Copyright (c) 2023 juicity
License GNU AGPLv3 <https://github.com/juicity/juicity/blob/main/LICENSE>
```
