### PR TITLE
feat/chore: support to forward to v2ray-plugin nodes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/juicity/juicity
 go 1.21.0
 
 require (
-	github.com/daeuniverse/outbound v0.0.0-20230814161100-5d9b25e38843
+	github.com/daeuniverse/outbound v0.0.0-20240101085641-7932e7df927d
 	github.com/daeuniverse/softwind v0.0.0-20231230065827-eed67f20d2c1
 	github.com/google/uuid v1.3.0
 	github.com/miekg/dns v1.1.55

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/andybalholm/brotli v1.0.5 h1:8uQZIdzKmjc/iuPu7O2ioW48L81FgatrcpfFmiq/
 github.com/andybalholm/brotli v1.0.5/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
-github.com/daeuniverse/outbound v0.0.0-20230814161100-5d9b25e38843 h1:DQCB9XdxWmI9ySh7lh1Yyer+1RM+d+1oXG586NBPJ5U=
-github.com/daeuniverse/outbound v0.0.0-20230814161100-5d9b25e38843/go.mod h1:0MOSc+twby808YzJjBA2VOSd928vLQFhUzHLSdL7aKM=
+github.com/daeuniverse/outbound v0.0.0-20240101085641-7932e7df927d h1:hEZDwJvoTATxtNU8/kirJP9GK0tFxekXzT00cGXO0xg=
+github.com/daeuniverse/outbound v0.0.0-20240101085641-7932e7df927d/go.mod h1:RlBqzRS0OfxDxmD1bgNfTmz9uzs8wQSmSG2vonMwSd0=
 github.com/daeuniverse/softwind v0.0.0-20231230065827-eed67f20d2c1 h1:qh16GLF9TfntnLIwos49rj7Yj4EHICDe9ToesIjTm1c=
 github.com/daeuniverse/softwind v0.0.0-20231230065827-eed67f20d2c1/go.mod h1:ly72DcZIxHlKbOEz1qaSCh99lr7ns8T5JLpfww8hXrI=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

1. Upgrade daeuniverse/outbound.
1. Support to forward to v2ray-plugin nodes.
1. Support UDP of shadowsocks + simple-obfs.

### Checklist

- [ ] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/juicity/juicity

### Full Changelogs

- [Implement ...]

### Issue Reference

<!--- If it fixes an open issue, please link to the issue here. -->

Closes #_[issue number]_

### Test Result

<!--- Attach test result here. -->
