### PR TITLE
fix: add allow_insecore=1 when cert need to pin

### DIFF
--- a/cmd/server/gen_link.go
+++ b/cmd/server/gen_link.go
@@ -123,6 +123,7 @@ func generateLink(arguments shared.Arguments) (string, error) {
 				return "", fmt.Errorf("generateCertChainHash: %w", err)
 			}
 			query.Set("pinned_certchain_sha256", hash)
+			query.Set("allow_insecure", "1")
 		}
 	}
 	link := url.URL{


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

`shadowrocket` needs `allow_insecure=1` if a self-signed cert is given.

### Checklist

- [ ] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/juicity/juicity

### Full Changelogs

- Add allow_insecure=1 when generate sharelink if a self-signed cert is given.

### Issue Reference

<!--- If it fixes an open issue, please link to the issue here. -->

Closes #_[issue number]_

### Test Result

<!--- Attach test result here. -->
<img width="1598" alt="image" src="https://github.com/juicity/juicity/assets/30586220/f7298c79-0e7e-479d-8ca3-c696229583a9">
