### PR TITLE
fix(cmd): use generic version flag to display ver info

### DIFF
--- a/cmd/client/run.go
+++ b/cmd/client/run.go
@@ -33,14 +33,6 @@ var (
 		TimeFormat: time.DateTime,
 	})
 
-	versionCmd = &cobra.Command{
-		Use:   "version",
-		Short: "Print out version info",
-		Run: func(cmd *cobra.Command, args []string) {
-			shared.PrintVersion(cgoEnabled)
-		},
-	}
-
 	runCmd = &cobra.Command{
 		Use:   "run",
 		Short: "To run juicity-client in the foreground.",
@@ -177,7 +169,6 @@ func init() {
 
 	// cmds
 	rootCmd.AddCommand(runCmd)
-	rootCmd.AddCommand(versionCmd)
 
 	shared.InitArgumentsFlags(runCmd)
 }

--- a/cmd/internal/shared/version.go
+++ b/cmd/internal/shared/version.go
@@ -12,19 +12,9 @@ func multiline(parts ...string) string {
 	return strings.Join(parts, "\n")
 }
 
-func PrintVersion(cgoEnabled int) {
-	fmt.Print(multiline(
-		fmt.Sprintf("juicity-client version %v", config.Version),
-		fmt.Sprintf("go runtime %v %v/%v", runtime.Version(), runtime.GOOS, runtime.GOARCH),
-		fmt.Sprintf("CGO_ENABLED: %v\n", cgoEnabled),
-		"Copyright (c) 2023 juicity",
-		"License GNU AGPLv3 <https://github.com/juicity/juicity/blob/main/LICENSE>",
-	))
-}
-
 func GetVersion(cgoEnabled int) string {
 	return multiline(
-		fmt.Sprintf("juicity-client version %v", config.Version),
+		fmt.Sprintf(config.Version),
 		fmt.Sprintf("go runtime %v %v/%v", runtime.Version(), runtime.GOOS, runtime.GOARCH),
 		fmt.Sprintf("CGO_ENABLED: %v", cgoEnabled),
 		"Copyright (c) 2023 juicity",

--- a/cmd/server/run.go
+++ b/cmd/server/run.go
@@ -22,14 +22,6 @@ var (
 		TimeFormat: time.DateTime,
 	})
 
-	versionCmd = &cobra.Command{
-		Use:   "version",
-		Short: "Print out version info",
-		Run: func(cmd *cobra.Command, args []string) {
-			shared.PrintVersion(cgoEnabled)
-		},
-	}
-
 	runCmd = &cobra.Command{
 		Use:   "run",
 		Short: "To run juicity-server in the foreground.",
@@ -110,7 +102,6 @@ func init() {
 
 	// cmds
 	rootCmd.AddCommand(runCmd)
-	rootCmd.AddCommand(versionCmd)
 
 	// flags
 	shared.InitArgumentsFlags(runCmd)


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

As the title suggests.

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/juicity/juicity

### Full Changelogs

- fix(cmd): use generic version flag to display ver info

### Issue Reference

<!--- If it fixes an open issue, please link to the issue here. -->

NA

### Test Result

<!--- Attach test result here. -->

```console
⯁ juicity git:(version-cmd) ❯❯❯ ./juicity-client -v
juicity-client version unstable-20240417.r126.81fdd6b
go runtime go1.22.1 linux/amd64
CGO_ENABLED: 0
Copyright (c) 2023 juicity
License GNU AGPLv3 <https://github.com/juicity/juicity/blob/main/LICENSE>
⯁ juicity git:(version-cmd) ❯❯❯ ./juicity-server -v
juicity-server version unstable-20240417.r126.81fdd6b
go runtime go1.22.1 linux/amd64
CGO_ENABLED: 0
Copyright (c) 2023 juicity
License GNU AGPLv3 <https://github.com/juicity/juicity/blob/main/LICENSE>
```